### PR TITLE
A little fix to parse a .jshintrc file

### DIFF
--- a/bin/jshint
+++ b/bin/jshint
@@ -39,7 +39,7 @@ while(args[0].substr(0, 2) == '--') {
         process.exit(-1);
     }
 
-    rc.cmdLine[curArg[0]] = curArg[1];
+    rc.cmdLine[curArg[0]] = curArg[1] === 'true';
 }
 
 function loadOptions(path, encoding) {

--- a/bin/jshint
+++ b/bin/jshint
@@ -42,6 +42,11 @@ while(args[0].substr(0, 2) == '--') {
     rc.cmdLine[curArg[0]] = curArg[1];
 }
 
+function loadOptions(path, encoding) {
+    var options = eval('(' + fs.readFileSync(path, encoding || 'utf8') + ')');
+    return options;
+}
+
 for(var i = 0; i < args.length; i++) {
     var file;
     if(args[i][0] == '/') {
@@ -53,7 +58,7 @@ for(var i = 0; i < args.length; i++) {
     // Grab jshint options. First we check installPrefix/etc/jshintrc.
     try {
         fs.statSync(process.installPrefix + '/etc/jshintrc');
-        rc.global = fs.readFileSync(process.installPrefix + '/etc/jshintrc', 'utf8');
+        rc.global = loadOptions(process.installPrefix + '/etc/jshintrc');
     } catch(err) {
         // Just assume it doesn't exist.
     }
@@ -61,7 +66,7 @@ for(var i = 0; i < args.length; i++) {
     // Next we check home
     try {
         fs.statSync('~/.jshintrc');
-        rc.home = fs.readFileSync('~/.jshintrc');
+        rc.home = loadOptions('~/.jshintrc');
     } catch(err) {
         // It's not there.
     }
@@ -69,7 +74,7 @@ for(var i = 0; i < args.length; i++) {
     // Next we check this dir
     try {
         fs.statSync(process.cwd() + '/.jshintrc');
-        rc.local = fs.readFileSync(process.cwd() + '/.jshintrc');
+        rc.local = loadOptions(process.cwd() + '/.jshintrc');
     } catch(err) {
         // Not there.
     }
@@ -80,6 +85,8 @@ for(var i = 0; i < args.length; i++) {
     jshintOpts = extend(jshintOpts, rc.home);
     jshintOpts = extend(jshintOpts, rc.local);
     jshintOpts = extend(jshintOpts, rc.cmdLine);
+    console.error(jshintOpts.toString());
+    console.error(jshintOpts.strict);
 
     if(!JSHINT(fs.readFileSync(file, 'utf8'), jshintOpts)) {
         if(args.length > 1) {

--- a/bin/jshint
+++ b/bin/jshint
@@ -85,8 +85,7 @@ for(var i = 0; i < args.length; i++) {
     jshintOpts = extend(jshintOpts, rc.home);
     jshintOpts = extend(jshintOpts, rc.local);
     jshintOpts = extend(jshintOpts, rc.cmdLine);
-    console.error(jshintOpts.toString());
-    console.error(jshintOpts.strict);
+
 
     if(!JSHINT(fs.readFileSync(file, 'utf8'), jshintOpts)) {
         if(args.length > 1) {


### PR DESCRIPTION
When this code above runs,
rc.global = fs.readFileSync(process.installPrefix + '/etc/jshintrc', 'utf8');
the variable "rc.global" will contains a string, not an object with options.
I write a function to evaluate the string and return a valid object.
