### PR TITLE
Ignore, rather than crash on, non-file items.

### DIFF
--- a/bin/jshint
+++ b/bin/jshint
@@ -88,6 +88,10 @@ for(var i = 0; i < args.length; i++) {
     jshintOpts = extend(jshintOpts, rc.local);
     jshintOpts = extend(jshintOpts, rc.cmdLine);
 
+    // Silently ignore items that aren't files (directories, ...)
+    if(!fs.statSync(file).isFile()){
+        continue;
+    }
 
     if(!JSHINT(fs.readFileSync(file, 'utf8'), jshintOpts)) {
         if(args.length > 1) {


### PR DESCRIPTION
The `fs.readFileSync(file, ...)` when loading files for JSHINT crashes the program when it sees anything besides files (or symlinks to files).

This patch checks for the items actually being files (or resolving to files) and silently skip over non-file items.
